### PR TITLE
Invoice information in the merchant show page tests/features

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -1,10 +1,11 @@
-class MerchantInvoicesController < ApplicationController 
+class MerchantInvoicesController < ApplicationController
 
-  def index 
+  def index
     @merchant = Merchant.find(params[:merchant_id])
   end
 
-  def show 
-    
+  def show
+    @merchant = Merchant.find(params[:merchant_id])
+    @invoice = Invoice.find(params[:id])
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,10 +1,12 @@
 class Invoice < ApplicationRecord
     enum status:[:'in progress', :cancelled, :completed]
-  
-  has_many :invoice_items
+
+  has_many :invoice_items, dependent: :destroy
+  has_many :transactions, dependent: :destroy
   has_many :items, through: :invoice_items
+  has_many :merchants, through: :items
 
   validates_presence_of :status
 
-  
+
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -8,3 +8,15 @@
     <span class="links">My Items</span>
     <span class="links">My Invoices</span>
 </div>
+
+<div id="invoice">
+  <% @invoice.invoice_items.each do |invoice| %>
+  <%= invoice.item.id %>
+    <% if @merchant.items.include?(invoice.item) %>
+      <p>Name: <%= invoice.item.name %></p>
+      <p>Quantity: <%= invoice.quantity %></p>
+      <p>Price: <%= invoice.unit_price %></p>
+      <p>Status: <%= invoice.status %></p>
+    <% end %>
+  <% end %>
+</div>

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+
+RSpec.describe 'merchants invoice show page' do
+  # Merchant Invoice Show Page: Invoice Item Information
+  #
+  # As a merchant
+  # When I visit my merchant invoice show page
+  # Then I see all of my items on the invoice including:
+  # - Item name
+  # - The quantity of the item ordered
+  # - The price the Item sold for
+  # - The Invoice Item status
+  # And I do not see any information related to Items for other merchants
+  it "has all of the item info from an invoice" do
+    merchant1 = Merchant.create!(name: "Poke Retirement homes")
+    merchant2 = Merchant.create!(name: "Rendolyn Guizs poke stops")
+    merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits")
+
+    item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
+    item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 2000, merchant_id: merchant2.id)
+    item3 = Item.create!(name: "Junk", description: 'junk you should want', unit_price: 500, merchant_id: merchant3.id)
+
+    customer1 = Customer.create!(first_name: "Parker", last_name: "Thomson")
+    invoice1 = Invoice.create!(status: "completed", customer_id: customer1.id)
+    invoice2 = Invoice.create!(status: "cancelled", customer_id: customer1.id)
+    invoice3 = Invoice.create!(status: "in progress", customer_id: customer1.id)
+    transaction1 = Transaction.create!(credit_card_number: "123456789123456789", result: "success", invoice_id: invoice1.id)
+    invoice_item1 = InvoiceItem.create!(quantity: 1, unit_price: item1.unit_price, status: "shipped", item_id: item1.id, invoice_id: invoice1.id)
+    invoice_item2 = InvoiceItem.create!(quantity: 2, unit_price: item2.unit_price, status: "pending", item_id: item2.id, invoice_id: invoice2.id)
+    invoice_item3 = InvoiceItem.create!(quantity: 3, unit_price: item3.unit_price, status: "packaged", item_id: item3.id, invoice_id: invoice3.id)
+
+    visit "/merchants/#{merchant1.id}/invoices/#{invoice1.id}"
+# save_and_open_page
+    within "div#invoice" do
+      expect(page).to have_content("Pikachu pics")
+      expect(page).to have_content("shipped")
+      expect(page).to have_content("Quantity: #{invoice_item1.quantity}")
+      expect(page).to have_content("Price: #{invoice_item1.unit_price}")
+      expect(page).to have_content("Status: #{invoice_item1.status}")
+      expect(page).to_not have_content("Quantity: #{invoice_item2.quantity}")
+      expect(page).to_not have_content("Price: #{invoice_item2.unit_price}")
+      expect(page).to_not have_content("Status: #{invoice_item2.status}")
+      expect(page).to_not have_content("Pokemon stuffy")
+      expect(page).to_not have_content("Junk")
+      expect(page).to_not have_content("pending")
+      expect(page).to_not have_content("packaged")
+    end
+
+    visit "/merchants/#{merchant2.id}/invoices/#{invoice2.id}"
+
+    within "div#invoice" do
+      expect(page).to have_content("Pokemon stuffy")
+      expect(page).to have_content("pending")
+      expect(page).to have_content("Quantity: #{invoice_item2.quantity}")
+      expect(page).to have_content("Price: #{invoice_item2.unit_price}")
+      expect(page).to have_content("Status: #{invoice_item2.status}")
+      expect(page).to_not have_content("Quantity: #{invoice_item3.quantity}")
+      expect(page).to_not have_content("Price: #{invoice_item3.unit_price}")
+      expect(page).to_not have_content("Status: #{invoice_item3.status}")
+      expect(page).to_not have_content("Pikachu pics")
+      expect(page).to_not have_content("Junk")
+      expect(page).to_not have_content("shipped")
+      expect(page).to_not have_content("packaged")
+    end
+
+    visit "/merchants/#{merchant3.id}/invoices/#{invoice3.id}"
+    # save_and_open_page
+
+    within "div#invoice" do
+      expect(page).to have_content("Junk")
+      expect(page).to have_content("packaged")
+      expect(page).to have_content("Quantity: #{invoice_item3.quantity}")
+      expect(page).to have_content("Price: #{invoice_item3.unit_price}")
+      expect(page).to have_content("Status: #{invoice_item3.status}")
+      expect(page).to_not have_content("Quantity: #{invoice_item1.quantity}")
+      expect(page).to_not have_content("Price: #{invoice_item1.unit_price}")
+      expect(page).to_not have_content("Status: #{invoice_item1.status}")
+      expect(page).to_not have_content("Pikachu pics")
+      expect(page).to_not have_content("Pokemon stuffy")
+      expect(page).to_not have_content("pending")
+      expect(page).to_not have_content("shipped")
+    end
+
+
+
+  end
+
+
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -3,13 +3,16 @@ require 'rails_helper'
 RSpec.describe Invoice do
 
   describe 'enums' do
-    it 'does' do 
+    it 'does' do
       expect { define_enum_for(:status).with_values(['in progress', 'cancelled', 'completed']) }
     end
   end
 
-  describe 'relationships' do 
-    it { should have_many :invoice_items }
+  describe 'relationships' do
+    it { should have_many (:invoice_items) }
+    it { should have_many (:transactions) }
+    it { should have_many(:items).through(:invoice_items) }
+    it { should have_many(:merchants).through(:items)}
   end
 
   describe 'validations' do


### PR DESCRIPTION
Added all tests and functionality to allow the MERCHANT INVOICE SHOW PAGE to display the Item name, Invoice id, Invoice quantity, Invoice unit_price, and Invoice status. No model methods were added I did also update some of the relationship tests and the models for the relationships but nothing major!