### PR TITLE
Merchant dashboard views

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -2,5 +2,6 @@ class MerchantsController < ApplicationController
 
   def show 
     @merchant = Merchant.find(params[:merchant_id])
+
   end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -1,5 +1,10 @@
 <h1>Little Esty Shop</h1>
 
 <div id = "merchant">
-<%=@merchant.name %>
+ <br><h3><%=@merchant.name %></h3><br>
+</div>
+
+<div id = "merchants">
+  <h4><%=link_to "#{@merchant.name}'s Item Index", "/merchants/#{@merchant.id}/items" %></h4>
+  <h4><%=link_to "#{@merchant.name}'s Invoice Index", "/merchants/#{@merchant.id}/invoices" %></h4>
 </div>

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -23,4 +23,36 @@ RSpec.describe 'Merchant Dashboard Page', type: :feature do
       expect(page).to have_content("#{merchant3.name}") 
     end
   end
+
+  it "can list a link to merchant items and invoices indexes" do 
+    merchant1 = Merchant.create!(name: "Poke Retirement homes")
+		merchant2 = Merchant.create!(name: "Rendolyn Guizs poke stops")
+		merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits")
+
+    item1 = Item.create!(name: "Pikachu pics", description: 'Cute pics with pikachu', unit_price: 1000, merchant_id: merchant1.id)
+    item2 = Item.create!(name: "Pokemon stuffy", description: 'Pikachu stuffed toy', unit_price: 2000, merchant_id: merchant1.id)
+    item3 = Item.create!(name: "Junk", description: 'junk you should want', unit_price: 500, merchant_id: merchant2.id)
+    item4 = Item.create!(name: "macrame runner", description: 'handmade macrame runner', unit_price: 2500, merchant_id: merchant3.id)
+
+    visit "/merchants/#{merchant1.id}/dashboard"
+    
+    within "div#merchants" do 
+      expect(page).to have_link("#{merchant1.name}'s Item Index")
+      expect(page).to have_link("#{merchant1.name}'s Invoice Index")
+    end
+
+    visit "/merchants/#{merchant2.id}/dashboard"
+
+    within "div#merchants" do  
+      expect(page).to have_link("#{merchant2.name}'s Item Index")
+      expect(page).to have_link("#{merchant2.name}'s Invoice Index") 
+    end
+
+    visit "/merchants/#{merchant3.id}/dashboard"
+
+    within "div#merchants" do 
+      expect(page).to have_link("#{merchant3.name}'s Item Index")
+      expect(page).to have_link("#{merchant3.name}'s Invoice Index")
+    end
+  end
 end


### PR DESCRIPTION
User Story-- COMPLETED
Merchant Dashboard Links

As a merchant,
When I visit my merchant dashboard
Then I see link to my merchant items index (/merchants/merchant_id/items)
And I see a link to my merchant invoices index (/merchants/merchant_id/invoices)--

**also had to update the name of the merchant controller and view from merchants_dashboard to just merchants