### PR TITLE
Admin merchant enable/disable

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -33,16 +33,4 @@ class AdminController < ApplicationController
   end
 end
 
-#  if params[:status].present?
-#       merchant.update_status(params[:status])
-#       redirect_to admin_merchants_path
 
-
-#      if merchant_params[:status]
-#       merchant.update(merchant_params)
-#       redirect_to "/admin/merchants"
-#  private
-
-#   def merchant_params
-#     params.permit(:name, :status)
-#   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -17,10 +17,32 @@ class AdminController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
   end
 
-  def update 
+  def update
     merchant = Merchant.find(params[:merchant_id]) 
-    merchant.update(name: params[:name])
-    redirect_to "/admin/merchants/#{merchant.id}"
-    flash.notice = 'The information has been successfully updated'
+    if params[:status] == 'enabled'
+      merchant.update(status: params[:status])
+      redirect_to "/admin/merchants"
+    elsif params[:status] == 'disabled'
+      merchant.update(status: params[:status])
+      redirect_to "/admin/merchants"
+    else
+      merchant.update(name: params[:name])
+      redirect_to "/admin/merchants/#{merchant.id}"
+      flash.notice = 'The information has been successfully updated'
+    end   
   end
 end
+
+#  if params[:status].present?
+#       merchant.update_status(params[:status])
+#       redirect_to admin_merchants_path
+
+
+#      if merchant_params[:status]
+#       merchant.update(merchant_params)
+#       redirect_to "/admin/merchants"
+#  private
+
+#   def merchant_params
+#     params.permit(:name, :status)
+#   end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -10,4 +10,8 @@ class Merchant < ApplicationRecord
   def merchant_invoice_by_item_id
     InvoiceItem.all.where(item_id: items.ids).pluck(:invoice_id).uniq
   end
+
+  def update_status(new_status)
+    update(status: new_status)
+  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -2,8 +2,16 @@
 
 <div id="admin_merchant">
   <% @merchants.each do |merchant| %>
+    <div id="merchant-<%="#{merchant.id}"%>">
     <p><h3><%= link_to merchant.name, "/admin/merchants/#{merchant.id}" %></h3></p>
-  <% end %><br>
+    <p>Status: <%= merchant.status %></p>
+    <% if merchant.status == "enabled"  %>
+    <%= button_to "Enable/Disable", "/admin/merchants/#{merchant.id}/update", action: :update, params: { status: :disabled}, method: :patch %>
+    <% elsif merchant.status == "disabled"%>
+    <%= button_to "Enable/Disable", "/admin/merchants/#{merchant.id}/update", action: :update, params: { status: :enabled}, method: :patch %>
+    <% end %>
+    </div>
+  <% end %>
 </div>
 
 <% @invoices.each do |invoice| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,5 @@ Rails.application.routes.draw do
   get 'admin/merchants/:merchant_id', to: 'admin#show_2'
   get 'admin/merchants/:merchant_id/edit', to: 'admin#edit'
   patch 'admin/merchants/:merchant_id/update', to: 'admin#update'
+  patch 'admin/merchants/:merchant_id/update-status', to: 'admin#update'
 end

--- a/db/migrate/20220731233332_add_status_to_merchants.rb
+++ b/db/migrate/20220731233332_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :string 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_27_154730) do
+ActiveRecord::Schema.define(version: 2022_07_31_233332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2022_07_27_154730) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status"
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -19,4 +19,53 @@ RSpec.describe 'Admin Merchants Index Page', type: :feature do
     expect(page).to have_content("Tarker Phomson manga emporium")
     expect(page).to have_content("Mlex Aora rods and reels")
   end
+
+  it "each mechant has a button to disable or enable the merchant" do 
+    merchant1 = Merchant.create!(name: "Poke Retirement homes", status: "enabled")
+    merchant2 = Merchant.create!(name: "Rendolyn Guiz's poke stops", status: "enabled")
+    merchant3 = Merchant.create!(name: "Dhirley Secasrio's knits and bits", status: "disabled")
+    merchant4 = Merchant.create!(name: "Eandace Ceckels toys'R'us", status: "disabled")
+
+    visit '/admin/merchants' 
+   
+    within "div#merchant-#{merchant1.id}" do
+      expect(page).to have_content("Poke Retirement homes")
+      expect(page).to have_content("Status: enabled")  
+      expect(page).to have_button('Enable/Disable')
+      click_button('Enable/Disable')
+      expect(current_path).to eq('/admin/merchants')
+      expect(page).to have_content("Status: disabled")  
+    end
+
+    visit "/admin/merchants"
+
+    within "div#merchant-#{merchant2.id}" do
+      expect(page).to have_content("Rendolyn Guiz's poke stops")
+      expect(page).to have_content("Status: enabled")  
+      expect(page).to have_button('Enable/Disable')
+      click_button('Enable/Disable')
+      expect(current_path).to eq('/admin/merchants')
+      expect(page).to have_content("Status: disabled") 
+    end
+
+    visit "/admin/merchants"
+
+    within "div#merchant-#{merchant3.id}" do
+      expect(page).to have_content("Dhirley Secasrio's knits and bits")
+      expect(page).to have_content("Status: disabled")  
+      expect(page).to have_button('Enable/Disable')
+      click_button('Enable/Disable')
+      expect(current_path).to eq('/admin/merchants')
+      expect(page).to have_content("Status: enabled") 
+    end
+
+     within "div#merchant-#{merchant4.id}" do
+      expect(page).to have_content("Eandace Ceckels toys'R'us")
+      expect(page).to have_content("Status: disabled")  
+      expect(page).to have_button('Enable/Disable')
+      click_button('Enable/Disable')
+      expect(current_path).to eq('/admin/merchants')
+      expect(page).to have_content("Status: enabled") 
+    end
+  end
 end


### PR DESCRIPTION
User Story -- COMPLETED
Admin Merchant Enable/Disable
As an admin,
When I visit the admin merchants index
Then next to each merchant name I see a button to disable or enable that merchant.
When I click this button
Then I am redirected back to the admin merchants index
And I see that the merchant's status has changed

***For the merchant status, I added the column to the merchants table, but did not set it up as an integer to do an enum. I'm not 100% sure how to set up do enums, so I did this user story without the use of enums.